### PR TITLE
Prevent overflows when left and right are both sufficiently large

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,14 @@ impl Indices {
     /// Uses integer division, so use with care.
     #[inline]
     pub fn middle(&self) -> usize {
-        (self.left + self.right) / 2
+        debug_assert!(
+            self.right >= self.left,
+            "right index ({}) < left index ({}), but expected right index >= left index",
+            self.right,
+            self.left,
+        );
+
+        self.left + ((self.right - self.left) / 2)
     }
 }
 

--- a/src/tests/indices.rs
+++ b/src/tests/indices.rs
@@ -73,15 +73,22 @@ fn creating_starting_indices_try_from_bisector_with_empty_slice_should_error() {
     zero_four = { 0, 4, 2 },
     one_one = { 1, 1, 1 },
     one_two = { 1, 2, 1 },
-
-    // The following test cases are not valid when used by Bisector, but pass here:
-    one_zero = { 1, 0, 0 },
-    two_zero = { 2, 0, 1 },
-    two_one = { 2, 1, 1 },
 )]
 fn middle_of_indices(left: usize, right: usize, expected_middle: usize) {
     let indices = Indices::new(left, right);
 
     let middle = indices.middle();
     assert_eq!(middle, expected_middle);
+}
+
+#[yare::parameterized(
+    one_zero = { 1, 0 },
+    two_zero = { 2, 0 },
+    two_one = { 2, 1 },
+)]
+#[should_panic]
+fn middle_of_invalid_indices(left: usize, right: usize) {
+    let indices = Indices::new(left, right);
+
+    indices.middle();
 }


### PR DESCRIPTION
Requires that right is always at least as large as left, otherwise, we'll underflow.